### PR TITLE
Remove apt-get upgrade

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:14.04
 
-RUN apt-get update && apt-get -y upgrade && apt-get -y install wget netcat
+RUN apt-get update && apt-get -y install wget netcat
 RUN mkdir -p /mattermost/data
 
 RUN touch /etc/init/mattermost.conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
 FROM ubuntu:14.04
 
-RUN apt-get update && apt-get -y install wget netcat
+RUN apt-get update && apt-get install -y \
+	wget \
+	netcat \
+	&& rm -rf /var/lib/apt/lists/*
 RUN mkdir -p /mattermost/data
 
 RUN touch /etc/init/mattermost.conf


### PR DESCRIPTION
apt-get upgrade [is discouraged by Docker](https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/#/apt-get)

This should also make the image noticeably smaller.
