### PR TITLE
Remove init conf file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,14 +3,6 @@ FROM ubuntu:14.04
 RUN apt-get update && apt-get -y upgrade && apt-get -y install wget netcat
 RUN mkdir -p /mattermost/data
 
-RUN touch /etc/init/mattermost.conf
-RUN echo $'start on runlevel [2345]\n\
-stop on runlevel [016]\n\
-respawn\n\
-chdir /mattermost\n\
-exec bin/platform\n'\
->> /etc/init/mattermost.conf
-
 RUN wget https://github.com/mattermost/platform/releases/download/v1.4.0/mattermost.tar.gz \
 	&& tar -xvzf mattermost.tar.gz && rm mattermost.tar.gz
 


### PR DESCRIPTION
mattermost is already being run as PID 1 from the docker-entry.sh script, so the configuration in /etc/init is at best doing nothing, but at worst the OS is attempting to run mattermost twice.
